### PR TITLE
Build failure nixpkgs 23.05

### DIFF
--- a/microchip/common/bsp/patches/0002-Riscv-Fix-build-against-binutils-2.38.patch
+++ b/microchip/common/bsp/patches/0002-Riscv-Fix-build-against-binutils-2.38.patch
@@ -1,6 +1,8 @@
-From: Ganga Ram <ganga.jaiswal@gmail.com>
-Date: Wed, 05 July 2023 06:15:22 +0400
-Subject: [PATCH] Riscv-Fix-build-against-binutils-2.38
+From 8afd811876b1ce8d6da6d5c804452a2b15805f5a Mon Sep 17 00:00:00 2001
+From: Ganga Ram <Ganga.Ram@tii.ae>
+Date: Wed, 5 Jul 2023 11:32:44 +0400
+Subject: [PATCH] From: Ganga Ram <Ganga.Ram@tii.ae> Date: Wed, 05 July 2023
+ 06:15:22 +0400 Subject: [PATCH] Riscv-Fix-build-against-binutils-2.38
 
 The following description is copied from the equivalent patch for the
 Linux Kernel proposed by Aurelien Jarno:
@@ -17,8 +19,7 @@ arch/riscv/cpu/cpu.c:95: Error: unrecognized opcode `csrw 0x003,0', extension `z
 
 More detail: https://patchwork.ozlabs.org/series/283391/mbox/
 
-Signed-off-by: Ganga Ram <ganga.jaiswal@gmail.com>
-
+Signed-off-by: Ganga Ram <Ganga.Ram@tii.ae>
 ---
  arch/riscv/Makefile | 11 ++++++++++-
  1 file changed, 10 insertions(+), 1 deletion(-)
@@ -28,9 +29,9 @@ index 0b80eb8d86..53d1194ffb 100644
 --- a/arch/riscv/Makefile
 +++ b/arch/riscv/Makefile
 @@ -24,7 +24,16 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
-   CMODEL = medany
+ 	CMODEL = medany
  endif
-
+ 
 -ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C) -mabi=$(ABI) \
 +RISCV_MARCH = $(ARCH_BASE)$(ARCH_A)$(ARCH_C)
 +
@@ -42,6 +43,9 @@ index 0b80eb8d86..53d1194ffb 100644
 +endif
 +
 +ARCH_FLAGS = -march=$(RISCV_MARCH) -mabi=$(ABI) \
-        -mcmodel=$(CMODEL)
-
+ 	     -mcmodel=$(CMODEL)
+ 
  PLATFORM_CPPFLAGS	+= $(ARCH_FLAGS)
+-- 
+2.39.2
+

--- a/microchip/common/bsp/patches/0002-Riscv-Fix-build-against-binutils-2.38.patch
+++ b/microchip/common/bsp/patches/0002-Riscv-Fix-build-against-binutils-2.38.patch
@@ -1,0 +1,47 @@
+From: Ganga Ram <ganga.jaiswal@gmail.com>
+Date: Wed, 05 July 2023 06:15:22 +0400
+Subject: [PATCH] Riscv-Fix-build-against-binutils-2.38
+
+The following description is copied from the equivalent patch for the
+Linux Kernel proposed by Aurelien Jarno:
+
+From version 2.38, binutils default to ISA spec version 20191213. This
+means that the csr read/write (csrr*/csrw*) instructions and fence.i
+instruction has separated from the `I` extension, become two standalone
+extensions: Zicsr and Zifencei. As the kernel uses those instruction,
+this causes the following build failure:
+
+arch/riscv/lib/cache.c:12: Error: unrecognized opcode `fence.i', extension `zifencei' required
+arch/riscv/cpu/cpu.c:94: Error: unrecognized opcode `csrs sstatus,a5', extension `zicsr' required
+arch/riscv/cpu/cpu.c:95: Error: unrecognized opcode `csrw 0x003,0', extension `zicsr' required
+
+More detail: https://patchwork.ozlabs.org/series/283391/mbox/
+
+Signed-off-by: Ganga Ram <ganga.jaiswal@gmail.com>
+
+---
+ arch/riscv/Makefile | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/arch/riscv/Makefile b/arch/riscv/Makefile
+index 0b80eb8d86..53d1194ffb 100644
+--- a/arch/riscv/Makefile
++++ b/arch/riscv/Makefile
+@@ -24,7 +24,16 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
+   CMODEL = medany
+ endif
+
+-ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C) -mabi=$(ABI) \
++RISCV_MARCH = $(ARCH_BASE)$(ARCH_A)$(ARCH_C)
++
++# Newer binutils versions default to ISA spec version 20191213 which moves some
++# instructions from the I extension to the Zicsr and Zifencei extensions.
++toolchain-need-zicsr-zifencei := $(call cc-option-yn, -mabi=$(ABI) -march=$(RISCV_MARCH)_zicsr_zifencei)
++ifeq ($(toolchain-need-zicsr-zifencei),y)
++	RISCV_MARCH := $(RISCV_MARCH)_zicsr_zifencei
++endif
++
++ARCH_FLAGS = -march=$(RISCV_MARCH) -mabi=$(ABI) \
+        -mcmodel=$(CMODEL)
+
+ PLATFORM_CPPFLAGS	+= $(ARCH_FLAGS)

--- a/microchip/common/bsp/uboot.nix
+++ b/microchip/common/bsp/uboot.nix
@@ -8,13 +8,13 @@ with pkgs; let
 in
 buildUBoot rec {
   pname = "uboot";
-  version = "linux4microchip+fpga-2023.02";
+  version = "linux4microchip+fpga-2023.06";
 
   src = fetchFromGitHub {
     owner = "polarfire-soc";
     repo = "u-boot";
-    rev = "b356a897b11ef19dcbe7870530f23f3a978c1714";
-    sha256 = "sha256-ouNLnDBeEsaY/xr5tAVBUtLlj0eylWbKdlU+bQ2Ciq4=";
+    rev = "7e19f9dff788025403ac6a34d9acf8736eef32ff";
+    sha256 = "sha256-1qmifjjNxPOUWRgZdQk6Ld5KGQk/PypSRK/ILPSsTLs";
   };
 
   extraMakeFlags = [

--- a/microchip/common/bsp/uboot.nix
+++ b/microchip/common/bsp/uboot.nix
@@ -21,7 +21,10 @@ buildUBoot rec {
           "OPENSBI=${opensbi}/share/opensbi/lp64/generic/firmware/fw_dynamic.bin"
   ];
 
-  patches = [ ./patches/0001-Boot-environment-for-Microchip-Iciclle-Kit.patch ];
+  patches = [
+    ./patches/0001-Boot-environment-for-Microchip-Iciclle-Kit.patch
+    ./patches/0002-Riscv-Fix-build-against-binutils-2.38.patch
+  ];
   defconfig = "${targetBoard}_defconfig";
   enableParallelBuilding = true;
   extraMeta.platforms = ["riscv64-linux"];


### PR DESCRIPTION
###### Description of changes
Fix https://github.com/NixOS/nixpkgs/issues/235179
Update Microchip uboot version to linux4microchip+fpga-2023.06
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [OK ] Tested the changes in your own NixOS Configuration
- [OK] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

